### PR TITLE
Adding support for pip>=20.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include requirements.txt
+include requirements.in
 recursive-include assets *

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Mnemocards comes with some pre-design formats:
 
 # Installation
 
-Using `pip`:
+Using PyPi package with `pip`:
 ```bash
 pip install --no-deps mnemocards
 pip install mnemocards
@@ -88,15 +88,20 @@ workaround.
 Installing from source code is even simpler.
 Clone this repository, move to the root of the project and run:
 ```bash
-python setup.py install
+pip install .
 ```
 
 If you want to contribute or develop use:
 ```bash
-python setup.py develop
+pip install -e .
 ```
 
 Remember to have at least the version 10 of `pip`.
+
+Avoid using `python setup.py install` or `python setup.py develop` because it
+does not understand direct references in the requirements and installs a
+different version of Genanki (installs the PyPi package instead of my GitHub
+fork).
 
 Consider the option of using Docker if you do not want to install
 the package and to set up all the needed environment.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 
 import os
-from os import listdir
 
 from setuptools import setup, find_packages
 try: # for pip >= 10
@@ -23,8 +22,15 @@ with open(os.path.join(PACKAGE_NAME, "_version.py")) as file:
     exec(file.read())
 
 # Read requirements.
-req = parse_requirements("requirements.txt", session="hack")
-REQUIREMENTS = [str(ir.req) for ir in req]
+req = parse_requirements("requirements.in", session="hack")
+REQUIREMENTS = []
+for i in req:
+    if getattr(i, "req") is not None:
+        REQUIREMENTS.append(str(i.req))
+    elif getattr(i, "requirement") is not None:  # pip >= 20.1
+        REQUIREMENTS.append(str(i.requirement))
+    else:
+        print("I don't understand this requirement...")
 print("Requirements:", REQUIREMENTS)
 
 # Install all packages in the current dir except tests.

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ with open(os.path.join(PACKAGE_NAME, "_version.py")) as file:
 req = parse_requirements("requirements.in", session="hack")
 REQUIREMENTS = []
 for i in req:
-    if getattr(i, "req") is not None:
+    if getattr(i, "req", None) is not None:
         REQUIREMENTS.append(str(i.req))
-    elif getattr(i, "requirement") is not None:  # pip >= 20.1
+    elif getattr(i, "requirement", None) is not None:  # pip >= 20.1
         REQUIREMENTS.append(str(i.requirement))
     else:
         print("I don't understand this requirement...")


### PR DESCRIPTION
A new pip version was released yesterday (20.1) and the install process stopped working. The new version is failing in this line:
```python
REQUIREMENTS = [str(ir.req) for ir in req]
```
because `ir.req` is not defined. The new value is stored in `ir.requirement`.

Updating README install instructions to be sure that the Genanki dependency is installed correctly. Now we are using `pip install .` instead of `python setup.py install`. The second one uses `easy_install` for installing the dependencies and it's not detecting a repository URL and it's downloading the last PyPi package of Genanki. [More info about this](https://stackoverflow.com/a/45863466/5114276).