### PR TITLE
Fix nonetype error and minor fixes to autogenerate formatting

### DIFF
--- a/mnemocards/builders/autogenerate_builder.py
+++ b/mnemocards/builders/autogenerate_builder.py
@@ -253,7 +253,8 @@ class AutogenerateBuilder(VocabularyBuilder, object):
         words = tsv.scrape_words_from_file(settings["filename"])
         translations = tsv.get_translation(
             words, settings["lang"]["original"], settings["lang"]["translation"])
-        cards = [tsv.prepare_card_fields(trans) for trans in translations]
+        cards = [tsv.prepare_card_fields(
+            trans) for trans in translations if tsv.prepare_card_fields(trans)]
         for card in cards:
             card["tags"] = settings["tags"]
 

--- a/mnemocards/maketsv.py
+++ b/mnemocards/maketsv.py
@@ -100,7 +100,10 @@ def format_explanations(list_obj, explanation_name, main_translation=None):
                     try:
                         synonyms_orig_lang = f'<div class="line_2">{line[2]}</div>'
                     except IndexError:
-                        synonyms_orig_lang = ''
+                        synonyms_orig_lang = '</br>'
+
+                if synonyms_orig_lang == '<div class="line_2">None</div>':
+                    synonyms_orig_lang = '</br>'
 
                 formatted_explanation += synonym_dest_lang + synonyms_orig_lang
 


### PR DESCRIPTION
Made this PR with bug fix from https://github.com/guiferviz/mnemocards/pull/10 but removed redundant code for easier coordination of the PR. Now even if words don't have translations (like acronyms) they just be skipped during autogeneration of cards.

Besides bug fix this PR also adds a small improvement for autogenerated card formatting, adding breaks tag for definitions in translated cards, for readability - now when definitions don't have example it will add a break between it and the next one.

@guiferviz please close https://github.com/guiferviz/mnemocards/pull/10 since it requires its author's change of code and just pull this one.