### PR TITLE
Fix a bug in nightmode on PC client, add "show tags" flag for markdown cards, close issue #4, close issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Depend on the type you can add more properties.
 {
     "type": "markdown",
     "file": "math.cards",
+    "show_tags": true,
     "card_properties": {
         "tags": ["math"]
     }
@@ -315,6 +316,9 @@ Depend on the type you can add more properties.
 ```
 
 Apart from `type` and `file` you can add:
+* `show_tags`.
+This flag set to true will display at the top of the cards tags for it both from `cards_config.json` and from `tags` property in the markdown card header ([as described in *.cards format section](#cards-file-format)).  
+By default false.
 * `card_properties`.
 Properties that are applied to all the cards in this file.
 For exampe: using this property you avoid setting tags in all the cards inside

--- a/examples/computer_science/cards_config.json
+++ b/examples/computer_science/cards_config.json
@@ -10,6 +10,7 @@
                         {
                             "type": "markdown",
                             "file": "cs.cards",
+                            "show_tags": true,
                             "card_properties": {
                                 "tags": ["computer_science"]
                             }

--- a/mnemocards/assets/css/highlight/github.css
+++ b/mnemocards/assets/css/highlight/github.css
@@ -4,6 +4,7 @@
  */
 .codehilite .hll { background-color: #ffffcc }
 .codehilite  { background: #f8f8f8; }
+.nightMode .codehilite { background: #000000;}
 .codehilite .c { color: #6a737d } /* Comment */
 .codehilite .err {  } /* Error */
 .codehilite .k { color: #d73a49 } /* Keyword */

--- a/mnemocards/assets/css/markdown_github.css
+++ b/mnemocards/assets/css/markdown_github.css
@@ -729,8 +729,7 @@ pre {
   padding: 16px;
 }
 
-.nightMode .highlight pre,
-pre {
+.nightMode pre {
   background-color: #000000;
 }
 

--- a/mnemocards/assets/css/markdown_github.css
+++ b/mnemocards/assets/css/markdown_github.css
@@ -729,6 +729,11 @@ pre {
   padding: 16px;
 }
 
+.nightMode .highlight pre,
+pre {
+  background-color: #000000;
+}
+
 pre code {
   background-color: transparent;
   border: 0;

--- a/mnemocards/builders/markdown_card_builder.py
+++ b/mnemocards/builders/markdown_card_builder.py
@@ -98,7 +98,7 @@ def change_mathjax_delimiters(text):
     # Using (?<!\\) two backslashes because if not the regex things you are
     # escaping the parenthesis.
     text = re.sub(r"\$\$\s*(.+?)(?<!\\)\s*\$\$", process_math_match, text,
-            flags=re.S)
+                  flags=re.S)
     # Inline math.
     text = re.sub(r"(?<![$\\])\$([^\n]+?)(?<!\\)\$", r"\\\\(\1\\\\)", text)
     # Escaped dollar$.
@@ -150,6 +150,8 @@ class MarkdownCardBuilder(object):
         tags = []
         if card_properties is not None:
             tags = card_properties.get("tags", [])
+        show_tags = src.get("show_tags", False)
+
         # Read markdown file.
         filename = os.path.join(data_dir, src["file"])
         with open(filename) as file:
@@ -165,7 +167,7 @@ class MarkdownCardBuilder(object):
                 if "tags" in metadata:
                     note_tags.extend(metadata.get("tags").split(","))
                 # Add tag list to the header.
-                if len(note_tags) > 0:
+                if len(note_tags) > 0 and show_tags:
                     header = "*Tags: " + ", ".join(note_tags) + "*\n" + header
                 header, m = generate_html(header, data_dir, src)
                 media.extend(m)
@@ -180,4 +182,3 @@ class MarkdownCardBuilder(object):
                 )
                 cards.append(my_note)
         return cards, media
-

--- a/mnemocards/clean.py
+++ b/mnemocards/clean.py
@@ -2,7 +2,7 @@
 import sys
 
 sys.path.append("/usr/share/anki")
-from anki import Collection
+from anki import collection
 
 from mnemocards.utils import create_check_collection_path
 
@@ -28,7 +28,7 @@ def clean(collection_path=None, profile=None):
     # Get an existing collection path. Error if not exists.
     collection_path = create_check_collection_path(collection_path, profile)
     # Create collection.
-    col = Collection(collection_path)
+    col = collection(collection_path)
     # Get notes to remove.
     notes = col.db.list(QUERY)
     # Remove non-updated notes.

--- a/mnemocards/import_command.py
+++ b/mnemocards/import_command.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from anki import Collection
+from anki import collection
 from anki.importing.apkg import AnkiPackageImporter
 
 from mnemocards.utils import create_check_collection_path
@@ -15,7 +15,7 @@ def import_command(apkgs, collection_path=None, profile=None):
     # Anki should fix that I think...
     apkgs = [os.path.abspath(i) for i in apkgs]
     # Create collection.
-    col = Collection(collection_path)
+    col = collection(collection_path)
     # Import collection.
     for a in apkgs:
         AnkiPackageImporter(col, a).run()

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ Pygments
 pykakasi
 googletrans==3.1.0a0
 chardet==3.0.4
+idna==2.10 #both httpx and requests require idna<3 https://github.com/psf/requests/issues/5710
 # Anki dependencies.
 anki
 protobuf>=3.13.0  # needed because version pinned by mypy-protobuf gives error.


### PR DESCRIPTION
@guiferviz, hi yet again!

I started to make myself markdown cards for the first time and caught a bug. 
Markdown code blocks are broken if you display them on PC client switched to night mode. Background color for code block and for text in it is set to white and hence unreadable. 
<img src="https://user-images.githubusercontent.com/59960096/137330354-fe68f2fe-8e41-4fdf-8a29-d0b718382f39.png" width="300"/>

Code blocks worked just fine in day-mode on PC and in both modes on Android.
I added a couple of CSS properties for PC night mode for markdown cards. Now they look fine:
<img src="https://user-images.githubusercontent.com/59960096/137331386-f525bb57-c34e-4cae-af8a-fe8904681be9.png" width="300"/>

I tested this fix on win10 anki client and android client. Code blocks correctly change background color in all modes.

Also, I've noticed issue #4 and decided to add the "show_tags" flag for markdown while I was working with the code in that part of mnemocards. (also, you may notice that the screenshot in the issue contains the same bugs with white text on white background in night mode on a PC client!).
So now you can enable and disable tags showing on the markdown generated cards via flag in `cards_config.json` (disabled by default). I added a description of this in README
You can merge this PR and close #4.


