### PR TITLE
Fixing import collection

### DIFF
--- a/mnemocards/import_command.py
+++ b/mnemocards/import_command.py
@@ -1,8 +1,7 @@
-
 import os
 import sys
 
-from anki import collection
+from anki.collection import Collection
 from anki.importing.apkg import AnkiPackageImporter
 
 from mnemocards.utils import create_check_collection_path
@@ -15,10 +14,9 @@ def import_command(apkgs, collection_path=None, profile=None):
     # Anki should fix that I think...
     apkgs = [os.path.abspath(i) for i in apkgs]
     # Create collection.
-    col = collection(collection_path)
+    col = Collection(collection_path)
     # Import collection.
     for a in apkgs:
         AnkiPackageImporter(col, a).run()
     # Close collection.
     col.close()
-


### PR DESCRIPTION
Issue #18 describes that `from anki import Collection` was changed to `from anki import collection`.
`collection` is a module inside `anki`, but we need the `Collection` class, so it should be `from anki.collection import Collection`.

This PR reverts some of the changes made in #16 .