### PR TITLE
MEP04 Generators

### DIFF
--- a/doc/mep/mep03.adoc
+++ b/doc/mep/mep03.adoc
@@ -195,3 +195,29 @@ modifying the Mnemocards source code.
 We can use the `any2dict` function to read configurations files.  This allows
 users to write their configurations files in the format that they prefer.  They
 can even create a new reader just for reading configuration files.
+
+
+=== Options in configuration files
+
+In MEP02 we defined the new configuration files. In the hiragana example we
+have:
+
+[source,json]
+----
+"path": "hiragana.tsv"
+----
+
+If no more options need to be passed to the reader, this is a common way of set
+the reader.  Imagine now that you have a SSV file (Semicolon Separated
+Values), how can you read that file using the CSV reader with a different
+delimiter?  This is the way of providing extra information to the readers in
+the configuration file:
+
+[source,json]
+----
+"path": {
+    "path": "hiragana.ssv",
+    "reader": "csv",
+    "delimiter": ","
+}
+----

--- a/doc/mep/mep04.adoc
+++ b/doc/mep/mep04.adoc
@@ -3,4 +3,46 @@
 
 == MEP04: Generators
 
-En este MEP vamos a definir cual es la estructura de un generador.
+In this MEP we define the structure of a generator.
+
+
+=== Generator class
+
+A generator is a class with two main methods: validate and generate.
+
+.generator.py
+[source,python]
+----
+class Generator:
+    def validate(card_properties):
+        return card_properties
+
+    def generate(card_properties):
+        return Note
+----
+
+The validate method receives a dictionary as input and applies a schema. The
+validate method shall return a dictionary with the card_properties correctly
+validated and with all default values populated.
+
+Alternatively, instead of a validate method, a schema could be defined and
+Mnemocards could be in charge of validating that the dictionary returned by the
+reader complies with the restrictions imposed by the schema.  To do this, we
+would have to look for a library to validate schemas on dictionaries.  The
+approach is not yet fully decided and will be refined in future editions of
+this MEP.
+
+The generate method receives a dictionary with the card properties already
+validated and creates the Notes, i.e. it creates the objects that are required
+by Genanki to generate the apkg.
+
+Instead of receiving a dictionary as input, validate could return a dataclass
+and use that object as input for this function.  This way the input object has
+a structure that even linter itself would be able to understand.
+
+Again, this is something yet to be defined.  For the moment this MEP is just an
+overview of the proposed approach.
+
+Although we could separate these methods into two distinct classes, making each
+class do only one thing, I don't think that would provide any advantage at this
+point. What's more, it would probably complicate the code unnecessarily.

--- a/doc/mep/mep04.adoc
+++ b/doc/mep/mep04.adoc
@@ -1,0 +1,6 @@
+:source-highlighter: rouge
+
+
+== MEP04: Generators
+
+En este MEP vamos a definir cual es la estructura de un generador.


### PR DESCRIPTION
MEP with definitions related to the generators. The definitions are still a bit vague, they will be refined as the refactor gets closer to the generators. Work will start on the readers first.

Updating MEP03 with missing details about the configuration files.